### PR TITLE
[ch60779] [density chart] minor: Avoid blinking map when no actual difference is sent 

### DIFF
--- a/resource/config-event.js
+++ b/resource/config-event.js
@@ -30,6 +30,16 @@ function ConfigEvent(){
 
     // At start need backend compute since there is no data available
     let _needCoreDataUpdate = false;
+    let _needMapCentering = true;
+
+    Object.defineProperty(this, 'needMapCentering', {
+        get: function(){
+            return _needMapCentering;
+        },
+        set: function(val){
+            _needMapCentering = val;
+        }
+    });
 
     Object.defineProperty(this, 'needCoreDataUpdate', {
         get: function(){
@@ -110,10 +120,13 @@ function ConfigEvent(){
                 console.log("Detected changes for parameter geopointColumnName, old value:", _geopointColumnName, " - new value:", val);
                 _geopointColumnName = val;
                 if (!val){
+                    // New value of the geopointColumnName is empty
                     console.log("Detected empty geopointColumnName");
                     _needCoreDataUpdate = false;
                 } else {
                     _needCoreDataUpdate = true;
+                    _needMapCentering = true;
+                    console.log("Detected new geopoint column input.")
                 }
 
             }

--- a/resource/geo-density-chart.js
+++ b/resource/geo-density-chart.js
@@ -86,25 +86,26 @@ function GeoDensityChart(){
             if (layer.options.id){
                 console.log("[MapTile] Received previous maptile id:", layer.options.id);
                 let url;
-                let idTileMap;
+                let newBaseMap;
                 console.log("[MapTile] Received asked maptile id", mapTile);
                 switch (mapTile) {
                     case 'cartodb-positron':
                         url = 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png';
-                        idTileMap = "light_all";
+                        newBaseMap = "light_all";
                         break;
                     case 'cartodb-dark':
                         url = 'http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png';
-                        idTileMap = "dark_all";
+                        newBaseMap = "dark_all";
                         break;
                 }
-                if (layer.options.id !== idTileMap){
-                    console.log("[MapTile] Building new map tilelayer with id", idTileMap);
+                let previousBaseMap = layer.options.id;
+                if (previousBaseMap !== newBaseMap){
+                    console.log("[MapTile] Building new map tilelayer with id", newBaseMap);
                     _mapPointer.removeLayer(layer);
                     L.tileLayer(url, {
                         maxZoom: 18,
                         attribution: 'Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
-                        id: idTileMap,
+                        id: newBaseMap,
                         tileSize: 512,
                         zoomOffset: -1
                     }).addTo(_mapPointer).set;

--- a/resource/geo-density-chart.js
+++ b/resource/geo-density-chart.js
@@ -10,6 +10,7 @@ function GeoDensityChart(){
     let _position;
     let _tooltip;
     let _coreData = [];
+    let _tileMapProvider = null;
 
     let _intensity;
     let _radius;
@@ -71,7 +72,7 @@ function GeoDensityChart(){
     };
 
     this.addLeafletLayer = function(){
-        L.tileLayer('http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png', {
+        L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png', {
             maxZoom: 18,
             attribution: 'Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
             id: 'light_all',
@@ -84,23 +85,31 @@ function GeoDensityChart(){
         // iterate in the layers of the map
         _mapPointer.eachLayer(function(layer){
             if (layer.options.id){
+                console.log("[MapTile] Received previous maptile id:", layer.options.id);
                 let url;
-                _mapPointer.removeLayer(layer);
+                let idTileMap;
+                console.log("[MapTile] Received asked maptile id", mapTile);
                 switch (mapTile) {
                     case 'cartodb-positron':
-                        url = 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';
+                        url = 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png';
+                        idTileMap = "light_all";
                         break;
                     case 'cartodb-dark':
-                        url = 'http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png';
+                        url = 'http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png';
+                        idTileMap = "dark_all";
                         break;
                 }
-                L.tileLayer(url, {
-                    maxZoom: 18,
-                    attribution: 'Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
-                    id: 'light_all',
-                    tileSize: 512,
-                    zoomOffset: -1
-                }).addTo(_mapPointer).set;
+                if (layer.options.id !== idTileMap){
+                    console.log("[MapTile] Building new map tilelayer with id", idTileMap);
+                    _mapPointer.removeLayer(layer);
+                    L.tileLayer(url, {
+                        maxZoom: 18,
+                        attribution: 'Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
+                        id: idTileMap,
+                        tileSize: 512,
+                        zoomOffset: -1
+                    }).addTo(_mapPointer).set;
+                }
             }
         });
     };

--- a/resource/geo-density-chart.js
+++ b/resource/geo-density-chart.js
@@ -10,7 +10,6 @@ function GeoDensityChart(){
     let _position;
     let _tooltip;
     let _coreData = [];
-    let _tileMapProvider = null;
 
     let _intensity;
     let _radius;

--- a/webapps/density-custom-chart/app.js
+++ b/webapps/density-custom-chart/app.js
@@ -126,7 +126,11 @@ function updateCoreData(configEvent, chartHandler) {
                 }
                 chartHandler.coreData = tempGeopoints;
                 chartHandler.render();
-                chartHandler.centerMap();
+                if (configEvent.needMapCentering) {
+                    console.log("Trying to center map.");
+                    chartHandler.centerMap();
+                    configEvent.needMapCentering = false;
+                }
                 chartHandler.initialised = true;
                 document.getElementById("error-message").text = "";
                 document.getElementById("error-warning-view").style.display = "none";


### PR DESCRIPTION
[ch60779](https://app.clubhouse.io/dataiku/story/60779/density-chart-chart-is-reloaded-when-showing-hiding-parameter-sections)
Avoid blinking map by comparing previous and next maptile ids, also setting maptile quality to highest quality