### PR TITLE
[ch60785] [density chart] Stick to the leaflet popup UX in Scatter Plot

### DIFF
--- a/resource/geo-density-chart.js
+++ b/resource/geo-density-chart.js
@@ -285,11 +285,11 @@ function formatTooltip(tooltip){
     if (!tooltip){
         return
     }
-    var formatedString = "<hr>";
+    var formattedString = "<hr>";
     for (var key of Object.keys(tooltip)) {
-        formatedString += key+": ";
-        formatedString += "<b>"+tooltip[key]+"</b>";
-        formatedString += "<br>";
+        formattedString += key+": ";
+        formattedString += "<b>"+tooltip[key]+"</b>";
+        formattedString += "<br>";
     }
-    return formatedString
+    return formattedString
 }

--- a/resource/geo-density-chart.js
+++ b/resource/geo-density-chart.js
@@ -282,7 +282,7 @@ function GeoDensityChart(){
  * @returns {string}
  */
 function formatTooltip(tooltip){
-    if (jQuery.isEmptyObject(tooltip)) {
+    if (tooltip && Object.keys(tooltip).length === 0 && tooltip.constructor === Object) {
         return ""
     }
     var formattedString = "<hr>";

--- a/resource/geo-density-chart.js
+++ b/resource/geo-density-chart.js
@@ -207,7 +207,7 @@ function GeoDensityChart(){
             .enter()
             .append("circle")
             .attr("cx", function(d) {
-                _tooltip.html("<div><strong>longitude</strong>: " + d.long + "<br><strong>latitude</strong>: "+d.lat+
+                _tooltip.html("<div>Lon: <strong>" + d.long + "</strong><br>Lat: <strong>"+d.lat+"</strong>" +
                     formatTooltip(d.tooltip) + "</div>");
                 return _mapPointer.latLngToLayerPoint([d.lat, d.long]).x
             })
@@ -217,8 +217,8 @@ function GeoDensityChart(){
             .attr("id", "circleBasicTooltip")
             .on('mouseover', function() { // handle the event user mouse is over the circle data point
                 _tooltip.style("visibility", "visible")
-                    .style("left", (d3.event.pageX + 50) + "px")
-                    .style("top", (d3.event.pageY - 28) + "px");
+                    .style("left", (d3.event.pageX+15) + "px")
+                    .style("top", (d3.event.pageY-25) + "px");
                 d3.select(this).transition()
                     .duration('50')
                     .attr("fill", "red")
@@ -285,13 +285,11 @@ function formatTooltip(tooltip){
     if (!tooltip){
         return
     }
-    var formatedString = "";
-    formatedString += "<div>";
+    var formatedString = "<hr>";
     for (var key of Object.keys(tooltip)) {
-        formatedString += "<b>"+key+"</b>: ";
-        formatedString += tooltip[key];
+        formatedString += key+": ";
+        formatedString += "<b>"+tooltip[key]+"</b>";
         formatedString += "<br>";
     }
-    formatedString += "</div>";
     return formatedString
 }

--- a/resource/geo-density-chart.js
+++ b/resource/geo-density-chart.js
@@ -279,11 +279,11 @@ function GeoDensityChart(){
  * Format the tooltip to be displayed in HTML
  * tooltip = {"reviews_per_month": 0.92, "room_type": "Private Room"};
  * @param tooltip
- * @returns {number}
+ * @returns {string}
  */
 function formatTooltip(tooltip){
-    if (!tooltip){
-        return
+    if (jQuery.isEmptyObject(tooltip)) {
+        return ""
     }
     var formattedString = "<hr>";
     for (var key of Object.keys(tooltip)) {

--- a/tests/js/05-test-stable.html
+++ b/tests/js/05-test-stable.html
@@ -113,7 +113,7 @@ function displayLocal(svg, closestMarker){
         .on('mouseover', function() { //function to add mouseover event
             tooltip.style("visibility", "visible")
                 .style("left", (d3.event.pageX) + "px")
-                .style("top", (d3.event.pageY - 28) + "px");
+                .style("top", (d3.event.pageY) + "px");
             d3.select(this).transition() //D3 selects the object we have moused over in order to perform operations on it
                 .duration('50') //how long we are transitioning between the two states (works like keyframes)
                 .attr("fill", "blue") //change the fill

--- a/webapps/density-custom-chart/app.js
+++ b/webapps/density-custom-chart/app.js
@@ -87,7 +87,14 @@ let tooltip = d3.select("#tooltip") // tooltip for the information of the point
     .text("This tooltip is meant to be visible on hover of datapoints")
     .style("z-index", 1000)
     .style("text-align", "left")
-    .style("background-color", "rgba(256, 256, 256, 1)");
+    .style("background-color", "rgba(256, 256, 256, 1)")
+    .style("border-radius", "12px")
+    .style("border-top-left-radius", "12px")
+    .style("border-top-right-radius", "12px")
+    .style("border-bottom-left-radius", "12px")
+    .style("border-bottom-right-radius", "12px")
+    .style("padding", "10px")
+    .style("font-size", "12px");
 
 chartHandler.tooltip = tooltip;
 

--- a/webapps/density-custom-chart/app.js
+++ b/webapps/density-custom-chart/app.js
@@ -93,7 +93,10 @@ let tooltip = d3.select("#tooltip") // tooltip for the information of the point
     .style("border-top-right-radius", "12px")
     .style("border-bottom-left-radius", "12px")
     .style("border-bottom-right-radius", "12px")
-    .style("padding", "10px")
+    .style("padding-left", "15px")
+    .style("padding-right", "15px")
+    .style("padding-top", "5px")
+    .style("padding-bottom", "5px")
     .style("font-size", "12px");
 
 chartHandler.tooltip = tooltip;

--- a/webapps/density-custom-chart/style.css
+++ b/webapps/density-custom-chart/style.css
@@ -1,10 +1,5 @@
 @import '/static/public/styles/1.0.0/dku-styles.css';
 
-#graph-stats {
-    position: absolute;
-    left: 10px;
-}
-
 #spinner {
     display: none;
     position: absolute;


### PR DESCRIPTION
[ch60785](https://app.clubhouse.io/dataiku/story/60785/density-chart-enhance-ux-of-tooltip-like-in-scatter-chart)

app.js: Replicate the same style properties for the tooltip
style.css: Removed unused style class
geo-density-chart.js: Replicate same style